### PR TITLE
Vanilla upgrade 2.0.1

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -40,6 +40,7 @@
         <!-- End Google Tag Manager (noscript) -->
 
         <header id="navigation" class="p-navigation">
+          <div class="row">
           <div class="p-navigation__banner">
             <div class="p-navigation__logo">
               <a class="p-navigation__link" href="/">
@@ -62,6 +63,7 @@
               </li>
             </ul>
           </nav>
+        </div>
         </header>
 
         <main id="main-content" class="inner-wrapper">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,40 +3,26 @@ layout: "base"
 ---
 
 <div class="page-content">
-  {{ content }}
+    {{ content }}
 </div>
 
 <div class="p-strip is-shallow">
   <div class="row">
-    <nav class="p-footer__nav">
-      <li class="p-inline-list__item"><a class="p-link--soft" href="/">Home</a></li>
-      <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/conjure-up/en/">User manual</a></li>
-      <li class="p-inline-list__item"><a class="p-link--soft p-link--external" href="https://docs.ubuntu.com/conjure-up/en/">User manual</a></li>
-      <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/conjure-up/en/dev-manual">Developer manual</a></li>
-      <li class="p-inline-list__item"><a class="p-link--soft p-link--external" href="https://docs.ubuntu.com/conjure-up/en/dev-manual">Developer manual</a></li>
-      <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://github.com/conjure-up/conjure-up">Contribute</a></li>
-      <li class="p-inline-list__item"><a class="p-link--soft p-link--external" href="https://github.com/conjure-up/conjure-up">Contribute</a></li>
-      <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://askubuntu.com/questions/tagged/conjure-up">askubuntu.com</a></li>
       <ul class="p-inline-list--middot">
-        <ul class="p-footer__links">
-          <li class="p-inline-list__item"><a class="p-link--soft" href="http://www.ubuntu.com/legal">Legal information</a></li>
-          <li class="p-footer__item">
-          <li class="p-inline-list__item"><a class="p-link--soft" href="https://github.com/canonical-websites/conjure-up.io/issues">Report a bug on this site</a></li>
-          <a class="p-footer__link p-link--strong" href="http://www.ubuntu.com/legal">Legal information</a>
-        </ul>
-        <p>&copy; Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-        <nav class="p-footer__nav">
-          <ul class="p-footer__links">
-            <li class="p-footer__item">
-              <a class="p-footer__link p-link--strong" href="http://www.ubuntu.com/legal">Legal information</a>
-            </li>
-            <li class="p-footer__item">
-              <a class="p-footer__link p-link--strong" href="https://github.com/canonical-websites/conjure-up.io/issues">Report a bug on this site</a>
-            </li>
-          </ul>
-        </nav>
-        <span class="u-off-screen">
-          <a href="#">Go to the top of the page</a>
-        </span>
+        <li class="p-inline-list__item"><a class="p-link--soft" href="/">Home</a></li>
+        <li class="p-inline-list__item"><a class="p-link--soft p-link--external" href="https://docs.ubuntu.com/conjure-up/en/">User manual</a></li>
+        <li class="p-inline-list__item"><a class="p-link--soft p-link--external" href="https://docs.ubuntu.com/conjure-up/en/dev-manual">Developer manual</a></li>
+        <li class="p-inline-list__item"><a class="p-link--soft p-link--external" href="https://github.com/conjure-up/conjure-up">Contribute</a></li>
+        <li class="p-inline-list__item"><a class="p-link--soft p-link--external" href="https://askubuntu.com/questions/tagged/conjure-up">askubuntu.com</a></li>
+        <li class="p-inline-list__item"><a class="p-link--soft p-link--external" href="https://rocket.ubuntu.com/channel/conjure-up">Rocketchat</a></li>
+      </ul>
+    <p>&copy; Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+    <ul class="p-inline-list--middot">
+      <li class="p-inline-list__item"><a class="p-link--soft" href="http://www.ubuntu.com/legal">Legal information</a></li>
+      <li class="p-inline-list__item"><a class="p-link--soft" href="https://github.com/canonical-websites/conjure-up.io/issues">Report a bug on this site</a></li>
+    </ul>
+    <span class="u-off-screen">
+      <a href="#">Go to the top of the page</a>
+    </span>
   </div>
-  </div>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,33 +3,40 @@ layout: "base"
 ---
 
 <div class="page-content">
-    {{ content }}
+  {{ content }}
 </div>
 
-<footer class="p-footer">
+<div class="p-strip is-shallow">
   <div class="row">
     <nav class="p-footer__nav">
+      <li class="p-inline-list__item"><a class="p-link--soft" href="/">Home</a></li>
+      <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/conjure-up/en/">User manual</a></li>
+      <li class="p-inline-list__item"><a class="p-link--soft p-link--external" href="https://docs.ubuntu.com/conjure-up/en/">User manual</a></li>
+      <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/conjure-up/en/dev-manual">Developer manual</a></li>
+      <li class="p-inline-list__item"><a class="p-link--soft p-link--external" href="https://docs.ubuntu.com/conjure-up/en/dev-manual">Developer manual</a></li>
+      <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://github.com/conjure-up/conjure-up">Contribute</a></li>
+      <li class="p-inline-list__item"><a class="p-link--soft p-link--external" href="https://github.com/conjure-up/conjure-up">Contribute</a></li>
+      <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://askubuntu.com/questions/tagged/conjure-up">askubuntu.com</a></li>
       <ul class="p-inline-list--middot">
-        <li class="p-inline-list__item"><a class="p-link--strong" href="/">Home</a></li>
-        <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/conjure-up/en/">User manual</a></li>
-        <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://docs.ubuntu.com/conjure-up/en/dev-manual">Developer manual</a></li>
-        <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://github.com/conjure-up/conjure-up">Contribute</a></li>
-        <li class="p-inline-list__item"><a class="p-link--external p-link--strong" href="https://askubuntu.com/questions/tagged/conjure-up">askubuntu.com</a></li>
-      </ul>
-    </nav>
-    <p>&copy; Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
-    <nav class="p-footer__nav">
-      <ul class="p-footer__links">
-        <li class="p-footer__item">
+        <ul class="p-footer__links">
+          <li class="p-inline-list__item"><a class="p-link--soft" href="http://www.ubuntu.com/legal">Legal information</a></li>
+          <li class="p-footer__item">
+          <li class="p-inline-list__item"><a class="p-link--soft" href="https://github.com/canonical-websites/conjure-up.io/issues">Report a bug on this site</a></li>
           <a class="p-footer__link p-link--strong" href="http://www.ubuntu.com/legal">Legal information</a>
-        </li>
-        <li class="p-footer__item">
-          <a class="p-footer__link p-link--strong" href="https://github.com/canonical-websites/conjure-up.io/issues">Report a bug on this site</a>
-        </li>
-      </ul>
-    </nav>
-    <span class="u-off-screen">
-      <a href="#">Go to the top of the page</a>
-    </span>
+        </ul>
+        <p>&copy; Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.</p>
+        <nav class="p-footer__nav">
+          <ul class="p-footer__links">
+            <li class="p-footer__item">
+              <a class="p-footer__link p-link--strong" href="http://www.ubuntu.com/legal">Legal information</a>
+            </li>
+            <li class="p-footer__item">
+              <a class="p-footer__link p-link--strong" href="https://github.com/canonical-websites/conjure-up.io/issues">Report a bug on this site</a>
+            </li>
+          </ul>
+        </nav>
+        <span class="u-off-screen">
+          <a href="#">Go to the top of the page</a>
+        </span>
   </div>
-</footer>
+  </div>

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@ sudo apt upgrade</code></pre>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="{{ site.asset_path }}3fd62570-docs.svg">
+          <img class="p-heading-icon__img" src="{{ site.asset_path }}3fd62570-docs.svg" alt="User manual icon">
           <h4 class="p-heading-icon__title">User manual</h4>
         </div>
         <p>Refer to the user manual to get a more detailed guide in how to get up and running with conjure-up.</p>
@@ -151,7 +151,7 @@ sudo apt upgrade</code></pre>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="{{ site.asset_path }}5c0fb313-ask+ubuntu.svg">
+          <img class="p-heading-icon__img" src="{{ site.asset_path }}5c0fb313-ask+ubuntu.svg" alt="Ask Ubuntu icon">
           <h4 class="p-heading-icon__title">Ask Ubuntu</h4>
         </div>
         <p>Troubleshoot and browse questions on the Ask Ubuntu StackExchange.</p>
@@ -161,7 +161,7 @@ sudo apt upgrade</code></pre>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="{{ site.asset_path }}d3ae9c8e-irc-icon-circle.svg">
+          <img class="p-heading-icon__img" src="{{ site.asset_path }}d3ae9c8e-irc-icon-circle.svg" alt="IRC icon">
           <h4 class="p-heading-icon__title"><abbr title="Internet Relay Chat">IRC</abbr></h4>
         </div>
         <p>Join the <code>#conjure-up</code> channel on <code>irc.freenode.net</code> if you&rsquo;re having problems with getting conjure-up running.</p>

--- a/index.html
+++ b/index.html
@@ -2,93 +2,91 @@
 layout: default
 ---
 
-<div class="p-strip--light is-deep is-bordered">
+<div class="p-strip--light is-deep">
   <div class="row u-vertically-center">
-    <div class="col-6">
-    <h1>Get started with big software, fast</h1>
-    <p>conjure-up lets you summon up a big-software stack as a &ldquo;spell&rdquo; &mdash; a&nbsp;model of the stack, combined with extra know-how to get you from an installed stack to a fully usable one. Start using your big software instead of learning how to deploy it.</p>
+    <div class="col-8">
+      <h1>Get started with big software, fast</h1>
+      <h2 class="p-heading--four">conjure-up lets you summon up a big-software stack as a &ldquo;spell&rdquo; &mdash; a&nbsp;model of the stack, combined with extra know-how to get you from an installed stack to a fully usable one. Start using your
+        big software instead of
+        learning how to deploy it.</h2>
     </div>
-    <div class="col-6 u-align--center u-hide--small">
+    <div class="col-4 u-align--center u-hide--small">
       <img src="{{ site.asset_path }}1abb8716-conjure-up-illustration.svg" alt="conjure-up illustration" />
     </div>
   </div>
 </div>
 
-<div class="p-strip is-bordered">
+<div class="p-strip">
   <div class="row">
-    <div class="col-12">
-      <h2>Get started</h2>
-      <p class="u-no-margin--bottom"><strong>Hardware requirements:</strong></p>
-      <ul class="p-inline-list--middot u-sv3">
-        <li class="p-inline-list__item">2 cores</li>
-        <li class="p-inline-list__item">16G RAM</li>
-        <li class="p-inline-list__item">32G Swap</li>
-        <li class="p-inline-list__item">250G SSD</li>
-        <li class="p-inline-list__item">64-bit only</li>
-      </ul>
-      <ol class="p-stepped-list--detailed">
-          <li class="p-list-step__item col-8">
-            <h3 class="p-list-step__title">
-              <span class="p-list-step__bullet">1</span>
-              Update your system
-            </h3>
-            <div class="p-list-step__content">
-              <p>It is always recommended to have the latest packages installed prior to running conjure-up:</p>
-              <pre><code>sudo apt update
+    <h2>Get started</h2>
+    <p class="p-heading--five u-no-margin--bottom">Hardware requirements:</p>
+    <ul class="p-inline-list--middot u-sv3">
+      <li class="p-inline-list__item">2 cores</li>
+      <li class="p-inline-list__item">16G RAM</li>
+      <li class="p-inline-list__item">32G Swap</li>
+      <li class="p-inline-list__item">250G SSD</li>
+      <li class="p-inline-list__item">64-bit only</li>
+    </ul>
+
+    <ol class="p-stepped-list--detailed">
+      <li class="p-stepped-list__item col-8">
+        <h3 class="p-stepped-list__title">
+          Update your system
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>It is always recommended to have the latest packages installed prior to running conjure-up:</p>
+          <pre><code>sudo apt update
 sudo apt upgrade</code></pre>
-            </div>
-          </li>
+        </div>
+      </li>
 
-          <li class="p-list-step__item col-8">
-            <h3 class="p-list-step__title">
-              <span class="p-list-step__bullet">2</span>
-              Install conjure-up
-            </h3>
-            <div class="p-list-step__content">
-              <p>conjure-up is available on Ubuntu Xenial 16.04 LTS and macOS</p>
-              <h5 class="u-no-padding--top">On Ubuntu</h5>
-              <pre><code>sudo snap install conjure-up --classic</code></pre>
-              <div class="p-notification">
-                <p class="p-notification__response">
-                  <span class="p-notification__status">Note:</span>
-                  <span class="p-notification__line">If above command fails you’ll want to make sure <strong>snapd</strong> is installed with <code>sudo apt install snapd</code></span>
-                </p>
-              </div>
+      <li class="p-stepped-list__item col-8">
+        <h3 class="p-stepped-list__title">
+          Install conjure-up
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>conjure-up is available on Ubuntu Xenial 16.04 LTS and macOS</p>
+          <h5 class="u-no-padding--top">On Ubuntu</h5>
+          <pre><code>sudo snap install conjure-up --classic</code></pre>
+          <div class="p-notification--information">
+            <p class="p-notification__response">
+              <span class="p-notification__status">Note:</span>
+              <span class="p-notification__line">If above command fails you’ll want to make sure <strong>snapd</strong> is installed with <code>sudo apt install snapd</code></span>
+            </p>
+          </div>
+          <h5 class="u-no-padding--top">On macOS</h5>
+          <pre><code>brew install conjure-up</code></pre>
+        </div>
+      </li>
 
-              <h5 class="u-no-padding--top">On macOS</h5>
-              <pre><code>brew install conjure-up</code></pre>
-            </div>
-          </li>
+      <li class="p-stepped-list__item col-8">
+        <h3 class="p-stepped-list__title">
+          Users of LXD
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>conjure-up requires that the minimum version of LXD be 3.0.0. Additionally, LXD should be configured prior to running.
+            <a href="https://docs.conjure-up.io/stable/en/user-manual#users-of-lxd" class="p-link--external">Follow the LXD setup documentation</a>
+          </p>
+        </div>
+      </li>
 
-          <li class="p-list-step__item col-8">
-            <h3 class="p-list-step__title">
-              <span class="p-list-step__bullet">3</span>
-              Users of LXD
-            </h3>
-            <div class="p-list-step__content">
-              <p>conjure-up requires that the minimum version of LXD be 3.0.0. Additionally, LXD should be configured prior to running.</p>
-              <p><a href="https://docs.conjure-up.io/stable/en/user-manual#users-of-lxd" class="p-link--external">Follow the LXD setup documentation</a></p>
-            </div>
-          </li>
+      <li class="p-stepped-list__item col-8">
+        <h3 class="p-stepped-list__title">
+          Running conjure-up
+        </h3>
+        <div class="p-stepped-list__content">
+          <p>To deploy solutions such as Kubernetes you will summon a spell:</p>
+          <pre><code>conjure-up kubernetes</code></pre>
+          <p>To see a list of all available spells run:</p>
+          <pre><code>conjure-up</code></pre>
+        </div>
+      </li>
 
-          <li class="p-list-step__item col-8">
-            <h3 class="p-list-step__title">
-              <span class="p-list-step__bullet">4</span>
-              Running conjure-up
-            </h3>
-            <div class="p-list-step__content">
-              <p>To deploy solutions such as Kubernetes you will summon a spell:</p>
-              <pre><code>conjure-up kubernetes</code></pre>
-              <p>To see a list of all available spells run:</p>
-              <pre><code>conjure-up</code></pre>
-            </div>
-          </li>
-        </ol>
-    </div>
+    </ol>
   </div>
 </div>
 
-<div class="p-strip--light is-bordered">
+<div class="p-strip--light">
   <div class="row">
     <div class="col-12">
       <h2>conjure-up spells</h2>
@@ -96,72 +94,75 @@ sudo apt upgrade</code></pre>
   </div>
   <div class="row u-equal-height">
     <div class="col-4 p-card--highlighted">
-      <div class="p-heading-icon">
+      <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="{{ site.asset_path }}dba11aee-kubernetes.svg" alt="Kubernetes logo" />
-          <h3 class="p-heading-icon__title">Kubernetes</h3>
+          <h4 class="p-heading-icon__title">Kubernetes</h4>
         </div>
+        <p>Get the Canonical Distribution of Kubernetes deployed and running all on a single machine.</p>
         <p><code>$ conjure-up kubernetes</code></p>
-        <p>Get the Canonical Distribution of Kubernetes deployed and running all on a single machine. </p>
         <p><a class="p-link--external" href="https://docs.ubuntu.com/conjure-up/en/walkthrough">Kubernetes with conjure-up</a></p>
       </div>
     </div>
 
     <div class="col-4 p-card--highlighted">
-      <div class="p-heading-icon">
+      <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="{{ site.asset_path }}873bc93e-OpenStack_Logo_Mark.svg" alt="OpenStack logo" />
-          <h3 class="p-heading-icon__title">OpenStack</h3>
+          <h4 class="p-heading-icon__title">OpenStack</h4>
         </div>
-        <p><code>$ conjure-up openstack</code></p>
         <p>Easily deploy real-world OpenStack on a single machine using LXD containers.</p>
+        <p><code>$ conjure-up openstack</code></p>
         <p><a class="p-link--external" href="https://www.ubuntu.com/download/cloud/conjure-up">OpenStack with conjure-up</a></p>
       </div>
     </div>
 
     <div class="col-4 p-card--highlighted">
-      <h3>More spells</h3>
-      <p><code>$ conjure-up</code></p>
-      <p>View all spells by using the command above, or view them in the GitHub repository.</p>
-      <p><a class="p-link--external" href="https://github.com/conjure-up/spells">Go to spell registry</a></p>
+      <div class="p-heading-icon--small">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" src="{{ site.asset_path }}c7b173c6-openstack-conjure-up.svg" alt="Spell picto" />
+          <h4 class="p-heading-icon__title">More spells</h4>
+        </div>
+        <p>View all spells by using the command above, or view them in the GitHub repository.</p>
+        <p><code>$ conjure-up</code></p>
+        <p><a class="p-link--external" href="https://github.com/conjure-up/spells">Go to spell registry</a></p>
+      </div>
     </div>
   </div>
 </div>
 
-<div class="p-strip is-bordered">
+<div class="p-strip">
   <div class="row">
     <div class="col-12">
       <h2>Getting help with conjure-up</h2>
     </div>
   </div>
-  <div class="row u-equal-height p-divider">
+  <div class="row p-divider">
     <div class="col-4 p-divider__block">
-      <div class="p-heading-icon">
+      <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="{{ site.asset_path }}3fd62570-docs.svg" alt="" />
-          <h3 class="p-heading-icon__title">User manual</h3>
+          <img class="p-heading-icon__img" src="{{ site.asset_path }}3fd62570-docs.svg">
+          <h4 class="p-heading-icon__title">User manual</h4>
         </div>
         <p>Refer to the user manual to get a more detailed guide in how to get up and running with conjure-up.</p>
         <p><a class="p-link--external" href="https://docs.ubuntu.com/conjure-up/en/">Read the user manual</a></p>
       </div>
     </div>
-
     <div class="col-4 p-divider__block">
-      <div class="p-heading-icon">
+      <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="{{ site.asset_path }}5c0fb313-ask+ubuntu.svg" alt="" />
-          <h3 class="p-heading-icon__title">Ask Ubuntu</h3>
+          <img class="p-heading-icon__img" src="{{ site.asset_path }}5c0fb313-ask+ubuntu.svg">
+          <h4 class="p-heading-icon__title">Ask Ubuntu</h4>
         </div>
         <p>Troubleshoot and browse questions on the Ask Ubuntu StackExchange.</p>
         <p><a class="p-link--external" href="https://askubuntu.com/questions/tagged/conjure-up">Go to askubuntu.com</a></p>
       </div>
     </div>
-
     <div class="col-4 p-divider__block">
-      <div class="p-heading-icon">
+      <div class="p-heading-icon--small">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" width="100" src="{{ site.asset_path }}d3ae9c8e-irc-icon-circle.svg" alt="" />
-          <h3 class="p-heading-icon__title"><abbr title="Internet Relay Chat">IRC</abbr></h3>
+          <img class="p-heading-icon__img" src="{{ site.asset_path }}d3ae9c8e-irc-icon-circle.svg">
+          <h4 class="p-heading-icon__title"><abbr title="Internet Relay Chat">IRC</abbr></h4>
         </div>
         <p>Join the <code>#conjure-up</code> channel on <code>irc.freenode.net</code> if you&rsquo;re having problems with getting conjure-up running.</p>
         <p><a class="p-link--external" href="https://webchat.freenode.net/">Go to webchat.freenode.net</a></p>
@@ -170,12 +171,12 @@ sudo apt upgrade</code></pre>
   </div>
 </div>
 
-<div class="p-strip--light is-bordered">
+<div class="p-strip--light">
   <div class="row">
-    <div class="col-12">
+    <div class="col-8">
       <h2>How to contribute to conjure-up</h2>
       <p>Create your own spells from scratch using the developer manual or build off existing spells via GitHub.</p>
-      <p><a class="p-button--neutral-icon" href="https://github.com/conjure-up/conjure-up">View on GitHub <img class="p-button--neutral-icon__image" src="{{ site.asset_path }}4f3fc618-github.svg" alt="GitHub logo" /></a></p>
+      <a href="https://github.com/conjure-up/conjure-up" class="p-button has-icon"><i class="p-icon--plus" style="background-image: url(https://assets.ubuntu.com/v1/f307a122-icon-github.svg)"></i> <span>View on GitHub</span></a>
     </div>
   </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/canonical-websites/conjure-up.io#readme",
   "devDependencies": {
-    "vanilla-framework": "1.8.1"
+    "vanilla-framework": "2.0.1"
   },
   "dependencies": {
     "watch-cli": "0.2.3",

--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -1,3 +1,1 @@
-$color-brand: #e95420;
-$color-link: $color-brand;
 $color-accent-background: #333;


### PR DESCRIPTION
## Done
- An updated version of the site to Vanilla 2.0.1
- Updated components, classes, and utilities based on release notes [here](https://github.com/canonical-web-and-design/vanilla-framework/releases/tag/v2.0.1)
- Visual update 😉 

## QA

1. Check out this feature branch
2. Run the site using the command `./run`
3. View the site locally in your web browser at: [http://0.0.0.0:8005/](http://0.0.0.0:8005/)
4. Or view via demo link generated below 👍 

## Screenshot
![conjure up io](https://user-images.githubusercontent.com/17748020/57631602-b0e7bf00-7597-11e9-8306-c21bdb86f1c2.png)